### PR TITLE
update title's class

### DIFF
--- a/themes/cerulean-outline/puml-theme-cerulean-outline.puml
+++ b/themes/cerulean-outline/puml-theme-cerulean-outline.puml
@@ -319,6 +319,7 @@ skinparam database {
 
 skinparam class {
 	$primary_scheme()
+	FontColor $LIGHT
 	HeaderBackgroundColor $PRIMARY-$PRIMARY_DARK
 	StereotypeFontColor $DARK
 	BorderThickness 1
@@ -443,7 +444,7 @@ skinparam useBetaStyle true
 
 !startsub mindmap
 
-<style> 
+<style>
 style mindmapDiagram {
   'Padding 8
   Margin 8


### PR DESCRIPTION
# Theme Name
cerulean-outline

# Description
I think is better to change the color of the title of a class to $LIGHT, as the primary_schema's FontColor is set to $DARK.

