### PR TITLE
Additional examples for testing theme consistency

### DIFF
--- a/examples/board-ex.puml
+++ b/examples/board-ex.puml
@@ -1,0 +1,15 @@
+@startboard
+
+!if %variable_exists("$THEME")
+title Board Diagram - $THEME theme
+!else
+title Board Diagram
+!endif
+
+A1
++U1.1
+++S1 R1
+++S1 R2 
++U1.2
+A2
+@endboard

--- a/examples/class-abstract-interface-ex.puml
+++ b/examples/class-abstract-interface-ex.puml
@@ -1,0 +1,39 @@
+@startuml
+
+!if %variable_exists("$THEME")
+title Class Diagram With Abstract Interface- $THEME theme
+!else
+title Class Diagram With Abstract Interface
+!endif
+
+abstract class AbstractList
+abstract AbstractCollection
+interface List
+interface Collection
+
+List <|-- AbstractList : AList to List
+Collection <|-- AbstractCollection : AColl to Coll
+
+Collection <|- List : List to Coll
+AbstractCollection <|- AbstractList : AList to AColl
+AbstractList <|-- ArrayList : ArList to AList
+
+class ArrayList {
+  Object[] elementData
+  size()
+}
+
+enum TimeUnit {
+  DAYS
+  HOURS
+  MINUTES
+}
+
+annotation SuppressWarnings
+
+annotation Annotation {
+  annotation with members
+  String foo()
+  String bar()
+}
+@enduml

--- a/examples/class-ex2.puml
+++ b/examples/class-ex2.puml
@@ -1,0 +1,23 @@
+@startuml
+
+!if %variable_exists("$THEME")
+title Class Diagram 2- $THEME theme
+!else
+title Class Diagram 2
+!endif
+
+abstract        abstract
+abstract class  "abstract class"
+annotation      annotation
+circle          circle
+()              circle_short_form
+class           class
+diamond         diamond
+<>              diamond_short_form
+entity          entity
+enum            enum
+'exception       exception
+interface       interface
+protocol        protocol
+struct          struct
+@enduml

--- a/examples/deployment-ex.puml
+++ b/examples/deployment-ex.puml
@@ -1,0 +1,37 @@
+@startuml
+
+!if %variable_exists("$THEME")
+title Deployment Diagram - $THEME theme
+!else
+title Deployment Diagram
+!endif
+
+actor actor
+actor/ "actor/"
+agent agent
+artifact artifact
+boundary boundary
+card card
+circle circle
+cloud cloud
+collections collections
+component component
+control control
+database database
+entity entity
+file file
+folder folder
+frame frame
+'hexagon hexagon
+interface interface
+label label
+node node
+package package
+person person
+queue queue
+rectangle rectangle
+stack stack
+storage storage
+usecase usecase
+usecase/ "usecase/"
+@enduml

--- a/examples/deployment-with-group-ex.puml
+++ b/examples/deployment-with-group-ex.puml
@@ -1,0 +1,36 @@
+@startuml
+
+!if %variable_exists("$THEME")
+title Deployment Diagram With Group- $THEME theme
+!else
+title Deployment Diagram With Group
+!endif
+
+package "Some Group" {
+  HTTP - [First Component]
+  [Another Component]
+}
+
+node "Other Groups" {
+  FTP - [Second Component]
+  [First Component] --> FTP
+}
+
+cloud {
+  [Example 1]
+}
+
+database "MySql" {
+  folder "This is my folder" {
+    [Folder 3]
+  }
+  frame "Foo" {
+    [Frame 4]
+  }
+}
+
+[Another Component] --> [Example 1]
+[Example 1] --> [Folder 3]
+[Folder 3] --> [Frame 4]
+
+@enduml

--- a/examples/gantt-ex.puml
+++ b/examples/gantt-ex.puml
@@ -1,0 +1,25 @@
+@startuml
+
+!if %variable_exists("$THEME")
+title Gantt Diagram - $THEME theme
+!else
+title Gantt Diagram
+!endif
+
+[Task1] lasts 10 days
+note bottom
+  memo1 ...
+  memo2 ...
+  explanations1 ...
+  explanations2 ...
+end note
+[Task2] lasts 4 days
+[Task1] -> [Task2]
+[Test  000] lasts 7 days and starts at [Task2]'s end and is 0% complete
+[Test  025] lasts 7 days and starts at [Task2]'s end and is 25% complete
+[Test  060] lasts 7 days and starts at [Task2]'s end and is 60% complete
+[Test  100] lasts 7 days and starts at [Task2]'s end and is 100% complete
+-- Separator title --
+[M1] happens on 5 days after [Task1]'s end
+-- end --
+@enduml

--- a/examples/gantt-wth-calendar-ex.puml
+++ b/examples/gantt-wth-calendar-ex.puml
@@ -1,0 +1,27 @@
+@startuml
+
+!if %variable_exists("$THEME")
+title Gantt Diagram With Calendar - $THEME theme
+!else
+title Gantt Diagram With Calendar
+!endif
+
+Project starts the 2020-12-14
+sunday are closed
+[Task1] lasts 10 days
+note bottom
+  memo1 ...
+  memo2 ...
+  explanations1 ...
+  explanations2 ...
+end note
+[Task2] lasts 4 days
+[Task1] -> [Task2]
+[Test  000] lasts 7 days and starts at [Task2]'s end and is 0% complete
+[Test  025] lasts 7 days and starts at [Task2]'s end and is 25% complete
+[Test  060] lasts 7 days and starts at [Task2]'s end and is 60% complete
+[Test  100] lasts 7 days and starts at [Task2]'s end and is 100% complete
+-- Separator title --
+[M1] happens on 5 days after [Task1]'s end
+-- end --
+@enduml

--- a/examples/json-ex.puml
+++ b/examples/json-ex.puml
@@ -1,0 +1,14 @@
+@startjson
+
+!if %variable_exists("$THEME")
+title JSON Diagram - $THEME theme
+!else
+title JSON Diagram 
+!endif
+
+{
+   "fruit":"Apple",
+   "size": "Large",
+   "color": ["Red", "Green"]
+}
+@endjson

--- a/examples/json-with-highlight-ex.puml
+++ b/examples/json-with-highlight-ex.puml
@@ -1,0 +1,16 @@
+@startjson
+
+!if %variable_exists("$THEME")
+title JSON Diagram With Highlight- $THEME theme
+!else
+title JSON Diagram With Highlight
+!endif
+
+
+#highlight "color" / "0"
+{
+   "fruit":"Apple",
+   "size": "Large",
+   "color": ["Red", "Green"]
+}
+@endjson

--- a/examples/mindmap-ex2.puml
+++ b/examples/mindmap-ex2.puml
@@ -1,0 +1,21 @@
+@startmindmap
+
+
+!if %variable_exists("$THEME")
+title Mindmap Diagram 2 - $THEME theme
+!else
+title Mindmap Diagram 2
+!endif
+
++ root
+**:right_1.1
+right_1.2;
+++ right_2
+
+left side
+
+-- left_1
+-- left_2
+**:left_3.1
+left_3.2;
+@endmindmap

--- a/examples/mindmap-with-boxless-ex.puml
+++ b/examples/mindmap-with-boxless-ex.puml
@@ -1,0 +1,21 @@
+@startmindmap
+
+
+!if %variable_exists("$THEME")
+title Mindmap Diagram With Boxless - $THEME theme
+!else
+title Mindmap Diagram With Boxless
+!endif
+
+
++ root node
+++ some first level node
++++_ second level node
++++_ another second level node
++++_ foo
++++_ bar
++++_ foobar
+++_ another first level node
+-- some first right level node
+--_ another first right level node
+@endmindmap

--- a/examples/nwdiag-ex.puml
+++ b/examples/nwdiag-ex.puml
@@ -1,0 +1,29 @@
+@startuml
+
+!if %variable_exists("$THEME")
+title Network Diagram - $THEME theme
+!else
+title Network Diagram
+!endif
+
+nwdiag {
+  network DMZ {
+      address = "y.x.x.x/24"
+      web01 [address = "y.x.x.1"];
+      web02 [address = "y.x.x.2"];
+  }
+
+   network Internal {
+    web01;
+    web02;
+    db01 [address = "w.w.w.z", shape = database];
+  } 
+
+    group {
+    description = "long group label";
+    web01;
+    web02;
+    db01;
+  }
+}
+@enduml

--- a/examples/object-ex2.puml
+++ b/examples/object-ex2.puml
@@ -1,0 +1,42 @@
+@startuml
+
+!if %variable_exists("$THEME")
+title Object Diagram 2 - $THEME theme
+!else
+title Object Diagram 2
+!endif
+
+object user1
+user1 : name = "Dummy"
+user1 : id = 123
+
+object user2 {
+  name = "Dummy"
+  id = 123
+}
+
+object o1
+object o2
+diamond dia
+object o3
+
+o1  --> dia
+o2  "1" --> "1" dia
+dia --> o3
+
+object London
+
+map CapitalCity {
+ UK *-> London
+ USA => Washington
+ Germany => Berlin
+}
+
+user1 --> CapitalCity : visits >
+
+json json {
+   "fruit":"Apple",
+   "size": "Large",
+   "color": ["Red", "Green"]
+}
+@enduml

--- a/examples/salt-ex.puml
+++ b/examples/salt-ex.puml
@@ -1,0 +1,19 @@
+@startsalt
+
+!if %variable_exists("$THEME")
+title Salt Diagram - $THEME theme
+!else
+title Salt Diagram 
+!endif
+
+{+
+  Just plain text
+  [This is my button]
+  ()  Unchecked radio
+  (X) Checked radio
+  []  Unchecked box
+  [X] Checked box
+  "Enter text here   "
+  ^This is a droplist^
+}
+@endsalt

--- a/examples/sequence-ex2.puml
+++ b/examples/sequence-ex2.puml
@@ -1,0 +1,25 @@
+@startuml
+
+
+!if %variable_exists("$THEME")
+title Sequence Diagram 2 - $THEME theme
+!else
+title Sequence Diagram 2
+!endif
+
+participant Participant as Foo
+actor       Actor       as Foo1
+boundary    Boundary    as Foo2
+control     Control     as Foo3
+entity      Entity      as Foo4
+database    Database    as Foo5
+collections Collections as Foo6
+queue       Queue       as Foo7
+Foo -> Foo1 : To actor 
+Foo -> Foo2 : To boundary
+Foo -> Foo3 : To control
+Foo -> Foo4 : To entity
+Foo -> Foo5 : To database
+Foo -> Foo6 : To collections
+Foo -> Foo7 : To queue
+@enduml

--- a/examples/sequence-group-ex.puml
+++ b/examples/sequence-group-ex.puml
@@ -1,0 +1,31 @@
+@startuml
+
+!if %variable_exists("$THEME")
+title Sequence Diagram With Group - $THEME theme
+!else
+title Sequence Diagram With Group
+!endif
+
+Alice -> Bob: Authentication Request
+
+alt successful case
+
+    Bob -> Alice: Authentication Accepted
+
+else some kind of failure
+
+    Bob -> Alice: Authentication Failure
+    group My own label
+    Alice -> Log : Log attack start
+        loop 1000 times
+            Alice -> Bob: DNS Attack
+        end
+    Alice -> Log : Log attack end
+    end
+
+else Another type of failure
+
+   Bob -> Alice: Please repeat
+
+end
+@enduml

--- a/examples/sequence-with-teoz.puml
+++ b/examples/sequence-with-teoz.puml
@@ -1,0 +1,16 @@
+@startuml
+
+!if %variable_exists("$THEME")
+title Sequence Diagram With TEOZ - $THEME theme
+!else
+title Sequence Diagram With TEOZ
+!endif
+
+!pragma teoz true
+Alice -> Bob : hello
+& Bob -> Charlie : hi
+group A teoz group
+Alice -> Bob : hello
+& Bob -> Charlie : ha
+end
+@enduml

--- a/examples/state-ex2.puml
+++ b/examples/state-ex2.puml
@@ -1,0 +1,26 @@
+@startuml
+
+!if %variable_exists("$THEME")
+title State Diagram 2 - $THEME theme
+!else
+title State Diagram 2
+!endif
+
+state choice1 <<choice>>
+state fork1   <<fork>>
+state join2   <<join>>
+state end3    <<end>>
+
+[*]     --> choice1 : from start\nto choice
+choice1 --> fork1   : from choice\nto fork
+choice1 --> join2   : from choice\nto join
+choice1 --> end3    : from choice\nto end
+
+fork1   ---> State1 : from fork\nto state
+fork1   --> State2  : from fork\nto state
+
+State2  --> join2   : from state\nto join
+State1  --> [*]     : from state\nto end
+
+join2   --> [*]     : from join\nto end
+@enduml

--- a/examples/state-with-point-ex.puml
+++ b/examples/state-with-point-ex.puml
@@ -1,0 +1,22 @@
+@startuml
+
+!if %variable_exists("$THEME")
+title State Diagram With Point  - $THEME theme
+!else
+title State Diagram With Point
+!endif
+
+state Somp {
+  state entry1 <<entryPoint>>
+  state entry2 <<entryPoint>>
+  state sin
+  entry1 --> sin
+  entry2 -> sin
+  sin -> sin2
+  sin2 --> exitA <<exitPoint>>
+}
+
+[*] --> entry1
+exitA --> Foo
+Foo1 -> entry2
+@enduml

--- a/examples/swimlane-ex.puml
+++ b/examples/swimlane-ex.puml
@@ -1,5 +1,11 @@
 @startuml
 
+!if %variable_exists("$THEME")
+title Swinlane Diagram - $THEME theme
+!else
+title Swinlane Diagram 
+!endif
+
 |Actor_For_red|
 start
 if (color?) is (red) then

--- a/examples/timing-ex.puml
+++ b/examples/timing-ex.puml
@@ -1,0 +1,25 @@
+@startuml
+
+!if %variable_exists("$THEME")
+title Timing Diagram  - $THEME theme
+!else
+title Timing Diagram
+!endif
+
+robust "Web Browser" as WB
+concise "Web User" as WU
+
+WB is Initializing
+WU is Absent
+
+@WB
+0 is idle
++200 is Processing
++100 is Waiting
+WB@0 <-> @50 : {50 ms lag}
+
+@WU
+0 is Waiting
++500 is ok
+@200 <-> @+150 : {150 ms}
+@enduml

--- a/examples/timing-ex2.puml
+++ b/examples/timing-ex2.puml
@@ -1,0 +1,35 @@
+@startuml
+
+
+!if %variable_exists("$THEME")
+title Timing Diagram 2 - $THEME theme
+!else
+title Timing Diagram 2
+!endif
+
+concise "CDAS_FETCH_EVENT" as CDAS_FETCH_EVENT
+concise "jb_2" as jb_2
+concise "LOAD_PERSISTENT_SESSIONS" as LOAD_PERSISTENT_SESSIONS
+scale 30 as 100 pixels
+title connector.log
+0 is {hidden}
+
+@CDAS_FETCH_EVENT
+0 is 80 : db
++80 is {-}
+120 is 95 : db
++95 is {-}
+
+@jb_2
+9 is 156 : db
++156 is {-}
+@59 <-> @+96 : 96 (db_rbs)
+
+@LOAD_PERSISTENT_SESSIONS
+141 is "(n/a)" : db
+
+highlight 0 to 9 : min
+highlight 141 to 165 : 3 connects\n(max)
+highlight 80  to 120 : 1 connect (min)
+highlight 215 to 250 
+@enduml

--- a/examples/usecase-ex2.puml
+++ b/examples/usecase-ex2.puml
@@ -1,0 +1,30 @@
+@startuml
+
+
+!if %variable_exists("$THEME")
+title Usecase Diagram 2 - $THEME theme
+!else
+title Usecase Diagram 2
+!endif
+
+
+left to right direction
+
+actor Guest as g
+package Professional {
+  actor Chef as c
+  actor "Food Critic" as fc
+}
+
+rectangle Restaurant {
+  usecase "Eat Food" as UC1
+  usecase "Pay for Food" as UC2
+  usecase "Drink" as UC3
+  usecase "Review" as UC4
+}
+
+fc --> UC4
+g --> UC1
+g --> UC2
+g --> UC3
+@enduml

--- a/examples/usecase-with-actorstyle-ex.puml
+++ b/examples/usecase-with-actorstyle-ex.puml
@@ -1,0 +1,14 @@
+@startuml
+
+!if %variable_exists("$THEME")
+title Usecase Diagram With Actor Style- $THEME theme
+!else
+title Usecase Diagram With Actor Style
+!endif
+
+skinparam actorStyle awesome
+:User: --> (Use)
+"Main Admin" as Admin
+"Use the application" as (Use)
+Admin --> (Admin the application)
+@enduml

--- a/examples/wbs-ex2.puml
+++ b/examples/wbs-ex2.puml
@@ -1,0 +1,17 @@
+@startwbs
+!if %variable_exists("$THEME")
+title Work Breakdown Diagram 2 - $THEME theme
+!else
+title Work Breakdown Diagram 2
+!endif
+
+* World
+** America 
+***_ Canada 
+***_ Mexico
+***_ USA
+** Europe
+***_  England
+***_  Germany
+***_  Spain
+@endwbs

--- a/examples/wire-ex.puml
+++ b/examples/wire-ex.puml
@@ -1,0 +1,22 @@
+@startwire
+
+'!if %variable_exists("$THEME")
+'title Wire Diagram - $THEME theme
+'!else
+'title Wire Diagram
+'!endif
+
+* BOX_1 [100x200]
+--
+move(100,0)
+* BOX_2 [50x175]
+
+BOX_1 ->  BOX_2 : abcd
+BOX_1 <-> BOX_2 : abcd
+BOX_1 <-  BOX_2 : abcd
+BOX_1 -   BOX_2 : abcd
+BOX_1 =>  BOX_2 : abcd
+BOX_1 <=> BOX_2 #red : abcd
+BOX_1 <=  BOX_2 : abcd
+BOX_1 =   BOX_2 : abcd
+@endwire

--- a/examples/yaml-ex.puml
+++ b/examples/yaml-ex.puml
@@ -1,0 +1,14 @@
+@startyaml
+
+!if %variable_exists("$THEME")
+title YAML Diagram - $THEME theme
+!else
+title YAML Diagram
+!endif
+
+fruit: Apple
+size: Large
+color:
+ - Red
+ - Green
+@endyaml

--- a/examples/yaml-with-highlight-ex.puml
+++ b/examples/yaml-with-highlight-ex.puml
@@ -1,0 +1,15 @@
+@startyaml
+
+!if %variable_exists("$THEME")
+title YAML With Highlight - $THEME theme
+!else
+title YAML With Highlight
+!endif
+
+#highlight "color" / "0"
+fruit: Apple
+size: Large
+color:
+ - Red
+ - Green
+@endyaml


### PR DESCRIPTION
This is a pull request to add additional examples based on  https://github.com/The-Lum/puml-themes-gallery/tree/main/input so the build script would generate addiitional diagram types/more use cases; this enables us to better check theme consistency e.g. for the gantt diagram. json, diagram over and above the existing diagrams.

Note that the while the example content is taken from the The-Lum's repo, the structure has been adapted to be consistent with the examples in this repo - . headings added, file name changes to match format in this repo.

I have used these as part of creating the `carbon-gray` theme